### PR TITLE
feat: Timeout duration

### DIFF
--- a/src/angular-masonry.js
+++ b/src/angular-masonry.js
@@ -16,6 +16,7 @@
 
       this.preserveOrder = false;
       this.loadImages = true;
+      this.timeoutDuration = 30;
 
       this.scheduleMasonryOnce = function scheduleMasonryOnce() {
         var args = arguments;
@@ -45,7 +46,7 @@
             $element.masonry.apply($element, args);
           });
           schedule = [];
-        }, 30);
+        }, self.timeoutDuration);
       };
 
       function defaultLoaded($element) {
@@ -135,7 +136,9 @@
             var loadImages = scope.$eval(attrs.loadImages);
             ctrl.loadImages = loadImages !== false;
             var preserveOrder = scope.$eval(attrs.preserveOrder);
-            ctrl.preserveOrder = (preserveOrder !== false && attrs.preserveOrder !== undefined); 
+            ctrl.preserveOrder = (preserveOrder !== false && attrs.preserveOrder !== undefined);
+            var timeoutDuration = scope.$eval(attrs.timeoutDuration);
+            ctrl.timeoutDuration = (!isNaN(timeoutDuration) && parseInt(timeoutDuration) > 30 ) ? parseInt(timeoutDuration) : 30;
             var reloadOnShow = scope.$eval(attrs.reloadOnShow);
             if (reloadOnShow !== false && attrs.reloadOnShow !== undefined) {
               scope.$watch(function () {


### PR DESCRIPTION
Allow to set a timeout-duration attribute to masonry directive element, setting a custom duration to the timeout set in scheduleMasonry method of MasonryCtrl.

```
<masonry preserve-order timeout-duration="1500">
  <!-- Your code here -->
</masonry>
```

It was necessary for us in case of loading 50+ elements containing images, as there seem to be a problem with imagesLoaded when loading an important amount of images.

That may be a bug of one of the dependencies, but this tiny feature dit the trick
